### PR TITLE
Allowing elements to be passed to service

### DIFF
--- a/addon/services/resize-detector.js
+++ b/addon/services/resize-detector.js
@@ -16,7 +16,8 @@ export default Ember.Service.extend({
   },
 
   setup(selector, callback) {
-    let element = document.querySelector(selector)
+    let element = (selector instanceof HTMLElement) ? selector : document.querySelector(selector);
+
     if (!element) {
       error(`service:resize-detector - could not find an element matching ${selector}`);
       return;
@@ -25,7 +26,8 @@ export default Ember.Service.extend({
   },
 
   teardown(selector, callback) {
-    let element = document.querySelector(selector)
+    let element = (selector instanceof HTMLElement) ? selector : document.querySelector(selector);
+
     if (element) {
       this.detector.removeListener(element, callback);
     }


### PR DESCRIPTION
I had misread the documentation when setting this up in our app and used `this.element` when setting up resize detection. This worked great until `0.4.0` was released and when jQuery was removed. I thought it would be nice if the service was still able to accept an element.